### PR TITLE
feat: add Payment schema for MongoDB with UUID and enums

### DIFF
--- a/models/payment.js
+++ b/models/payment.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+const { v4: uuidv4 } = require("uuid");
+
+paymentSchema = mongoose.Schema(
+  {
+    id: {
+      type: String,
+      default: uuidv4,
+      required: true,
+      immutable: true,
+    },
+    payment_mathond: {
+      type: String,
+      enum: ["Credit Card", "Debit Card", "PayPal"],
+      default: "Credit Card",
+    },
+    status: {
+      type: String,
+      enum: ["Pending", "Paid", "Failed"],
+      default: "Pending",
+    },
+    created_at: {
+      type: Date,
+      default: Date.now,
+    },
+    updated_at: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const Payment = mongoose.model("Payment", paymentSchema);
+module.exports = Payment;


### PR DESCRIPTION
- Introduced a Payment schema using Mongoose for handling payment data.
- Implemented the following fields:
  - `id`: Unique identifier (UUID v4) for each payment.
  - `payment_method`: Enum with options ["Credit Card", "Debit Card", "PayPal"] and a default of "Credit Card".
  - `status`: Enum with options ["Pending", "Paid", "Failed"] and a default of "Pending".
  - `created_at` and `updated_at`: Automatically managed timestamp fields.
- Enabled `timestamps` option for automatic creation and update tracking.
- Exported the schema as the `Payment` model for use in the application. ;