### PR TITLE
feat: add Location schema for MongoDB with UUID and validation

### DIFF
--- a/models/location.js
+++ b/models/location.js
@@ -1,0 +1,46 @@
+const mongoose = require("mongoose");
+const { v4: uuidv4 } = require("uuid");
+
+const locationSchema = mongoose.Schema(
+  {
+    id: {
+      type: String,
+      default: uuidv4,
+      unique: true,
+      immutable: true,
+    },
+    country: {
+      type: String,
+      required: true,
+      maxlength: 100,
+    },
+    city: {
+      type: String,
+      required: true,
+      maxlength: 100,
+    },
+    address: {
+      type: String,
+      required: true,
+      maxlength: 255,
+    },
+    zip_code: {
+      type: Number,
+      required: true,
+    },
+    created_at: {
+      type: Date,
+      default: Date.now,
+    },
+    updated_at: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const Location = mongoose.model("Location", locationSchema);
+module.exports = Location;


### PR DESCRIPTION
- Created a Location schema using Mongoose for managing location data.
- Implemented the following fields:
  - `id`: Unique identifier (UUID v4) for each location, immutable and unique.
  - `country`: Required field with a maximum length of 100 characters.
  - `city`: Required field with a maximum length of 100 characters.
  - `address`: Required field with a maximum length of 255 characters.
  - `zip_code`: Required numeric field for the postal code.
  - `created_at` and `updated_at`: Automatically managed timestamp fields.
- Enabled `timestamps` option for automatic creation and update tracking.
- Exported the schema as the `Location` model for use in the application.